### PR TITLE
Use ntdll instead of winapi since that was a winapi specific workaround.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winrt-notification"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["allenbenz"]
 keywords = ["notification", "windows", "toast", "notify"]
 readme = "README.md"

--- a/src/windows_check.rs
+++ b/src/windows_check.rs
@@ -19,8 +19,7 @@ use OSVERSIONINFOEXW;
 #[cfg(not(target_arch = "x86"))]
 type OSVERSIONINFOEX = OSVERSIONINFOEXW;
 
-#[cfg_attr(target_env = "gnu", link(name = "winapi_ntdll"))]
-#[cfg_attr(target_env = "msvc", link(name = "ntdll"))]
+#[link(name = "ntdll")]
 extern "system" {
     pub fn RtlGetVersion(lpVersionInformation: &mut OSVERSIONINFOEX) -> NTSTATUS;
 }


### PR DESCRIPTION
Since 3.0 we no longer use winapi in favor of the windows package.
So the winapi specific link workaround doesn't help and prevents msys environments from building the package with the gnu toolchain.

The windows crate will eventually be able to build using the gnu target without msys, but that's blocked on https://github.com/microsoft/windows-rs/issues/638 and https://github.com/rust-lang/rust/issues/58713.

Resolves #7 