### PR TITLE
Update Windows crate dependency to 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default-target = "x86_64-pc-windows-msvc"
 [dependencies]
 xml-rs = "0.8.3"
 strum = { version = "0.20", features = ["derive"] }
-windows = "0.3.1"
+windows = "0.8.0"
 
 [build-dependencies]
-windows = "0.3.1"
+windows = "0.8.0"

--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,10 @@
 // see https://microsoft.github.io/windows-docs-rs/doc/bindings/windows/ for possible bindings
 fn main() {
     windows::build!(
-        windows::win32::system_services::NTSTATUS,
-        windows::win32::windows_programming::OSVERSIONINFOEXA,
-        windows::win32::windows_programming::OSVERSIONINFOEXW,
-        windows::data::xml::dom::XmlDocument,
-        windows::ui::notifications::{ToastNotification, ToastNotificationManager},
+        Windows::Win32::SystemServices::NTSTATUS,
+        Windows::Win32::WindowsProgramming::OSVERSIONINFOEXA,
+        Windows::Win32::WindowsProgramming::OSVERSIONINFOEXW,
+        Windows::Data::Xml::Dom::XmlDocument,
+        Windows::UI::Notifications::{ToastNotification, ToastNotificationManager, ToastNotifier},
     );
 }

--- a/examples/reuse.rs
+++ b/examples/reuse.rs
@@ -17,7 +17,7 @@ fn main() {
         .show()
         // silently consume errors
         .expect("notification failed");
-    
+
     Toast::new(Toast::POWERSHELL_APP_ID)
         .title("another toast")
         .text1("line1")

--- a/examples/without_library.rs
+++ b/examples/without_library.rs
@@ -14,13 +14,15 @@ mod bindings {
 // and call windows::build! in a build.rs file
 // or have pregenerated code that does the same thing
 use bindings::{
-    windows::data::xml::dom::XmlDocument,
-    windows::ui::notifications::ToastNotification,
-    windows::ui::notifications::ToastNotificationManager,
-    windows::HString,
+    Windows::Data::Xml::Dom::XmlDocument,
+    Windows::UI::Notifications::ToastNotification,
+    Windows::UI::Notifications::ToastNotificationManager,
 };
 
-pub use windows::Error;
+pub use windows::{
+    Error,
+    HString,
+};
 
 fn main() {
     do_toast().expect("not sure if this is actually failable");
@@ -32,7 +34,7 @@ fn main() {
 fn do_toast() -> windows::Result<()> {
     let toast_xml = XmlDocument::new()?;
 
-    toast_xml.load_xml(HString::from(
+    toast_xml.LoadXml(HString::from(
         format!(r#"<toast duration="long">
                 <visual>
                     <binding template="ToastGeneric">
@@ -51,14 +53,14 @@ fn do_toast() -> windows::Result<()> {
     ))).expect("the xml is malformed");
 
     // Create the toast and attach event listeners
-    let toast_template = ToastNotification::create_toast_notification(toast_xml)?;
+    let toast_template = ToastNotification::CreateToastNotification(toast_xml)?;
 
     // If you have a valid app id, (ie installed using wix) then use it here.
-    let toast_notifier = ToastNotificationManager::create_toast_notifier_with_id(HString::from(
+    let toast_notifier = ToastNotificationManager::CreateToastNotifierWithId(HString::from(
         "{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\\WindowsPowerShell\\v1.0\\powershell.exe",
     ))?;
 
     // Show the toast.
     // Note this returns success in every case, including when the toast isn't shown.
-    toast_notifier.show(&toast_template)
+    toast_notifier.Show(&toast_template)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,10 +38,9 @@ mod bindings {
 }
 
 use bindings::{
-    windows::data::xml::dom::XmlDocument,
-    windows::ui::notifications::ToastNotification,
-    windows::ui::notifications::ToastNotificationManager,
-    windows::HString,
+    Windows::Data::Xml::Dom::XmlDocument,
+    Windows::UI::Notifications::ToastNotification,
+    Windows::UI::Notifications::ToastNotificationManager,
 };
 
 use std::fmt;
@@ -50,7 +49,10 @@ use std::path::Path;
 use xml::escape::escape_str_attribute;
 mod windows_check;
 
-pub use windows::Error;
+pub use windows::{
+    Error,
+    HString,
+};
 
 pub struct Toast {
     duration: String,
@@ -297,7 +299,7 @@ impl Toast {
             }
         };
 
-        toast_xml.load_xml(HString::from(format!(
+        toast_xml.LoadXml(HString::from(format!(
             "<toast {}>
                     <visual>
                         <binding template=\"{}\">
@@ -317,12 +319,12 @@ impl Toast {
         )))?;
 
         // Create the toast and attach event listeners
-        let toast_template = ToastNotification::create_toast_notification(toast_xml)?;
+        let toast_template = ToastNotification::CreateToastNotification(toast_xml)?;
 
         // Show the toast.
         let toast_notifier =
-            ToastNotificationManager::create_toast_notifier_with_id(HString::from(&self.app_id))?;
-        let result = toast_notifier.show(&toast_template);
+            ToastNotificationManager::CreateToastNotifierWithId(HString::from(&self.app_id))?;
+        let result = toast_notifier.Show(&toast_template);
         std::thread::sleep(std::time::Duration::from_millis(10));
         result
     }

--- a/src/windows_check.rs
+++ b/src/windows_check.rs
@@ -5,8 +5,8 @@ mod bindings {
 }
 
 use bindings::{
-    windows::win32::system_services::NTSTATUS,
-    windows::win32::windows_programming::*,
+    Windows::Win32::SystemServices::NTSTATUS,
+    Windows::Win32::WindowsProgramming::*,
 };
 
 #[cfg(target_arch = "x86")]
@@ -29,7 +29,7 @@ pub fn is_newer_than_windows81() -> bool {
         let mut info: OSVERSIONINFOEX = OSVERSIONINFOEX::default();
 
         if RtlGetVersion(&mut info) == NTSTATUS(0) {
-            info.dw_major_version > 6
+            info.dwMajorVersion > 6
         } else {
             false
         }


### PR DESCRIPTION
This update brings the `winrt-notification` crate in line with the latest published version of the `Windows` crate. The most noticeable difference is that the `Windows` crate now preserves the original casing of the Windows APIs. Less noticeable differences include faster build times. More info here: https://github.com/microsoft/windows-rs/blob/master/docs/changelog.md