### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ edition = '2018'
 default-target = "x86_64-pc-windows-msvc"
 
 [dependencies]
-xml-rs = "0.8.3"
-strum = { version = "0.20", features = ["derive"] }
-windows = "0.8.0"
+xml-rs = "0.8.4"
+strum = { version = "0.21.0", features = ["derive"] }
+windows = "0.21.1"
 
 [build-dependencies]
-windows = "0.8.0"
+windows = "0.21.1"

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,9 @@
 // see https://microsoft.github.io/windows-docs-rs/doc/bindings/windows/ for possible bindings
 fn main() {
     windows::build!(
-        Windows::Win32::SystemServices::NTSTATUS,
-        Windows::Win32::WindowsProgramming::OSVERSIONINFOEXA,
-        Windows::Win32::WindowsProgramming::OSVERSIONINFOEXW,
+        Windows::Win32::Foundation::NTSTATUS,
+        Windows::Win32::System::SystemInformation::OSVERSIONINFOEXW,
+        Windows::Win32::System::SystemInformation::OSVERSIONINFOEXA,
         Windows::Data::Xml::Dom::XmlDocument,
         Windows::UI::Notifications::{ToastNotification, ToastNotificationManager, ToastNotifier},
     );

--- a/examples/without_library.rs
+++ b/examples/without_library.rs
@@ -21,7 +21,7 @@ use bindings::{
 
 pub use windows::{
     Error,
-    HString,
+    HSTRING,
 };
 
 fn main() {
@@ -34,7 +34,7 @@ fn main() {
 fn do_toast() -> windows::Result<()> {
     let toast_xml = XmlDocument::new()?;
 
-    toast_xml.LoadXml(HString::from(
+    toast_xml.LoadXml(HSTRING::from(
         format!(r#"<toast duration="long">
                 <visual>
                     <binding template="ToastGeneric">
@@ -56,7 +56,7 @@ fn do_toast() -> windows::Result<()> {
     let toast_template = ToastNotification::CreateToastNotification(toast_xml)?;
 
     // If you have a valid app id, (ie installed using wix) then use it here.
-    let toast_notifier = ToastNotificationManager::CreateToastNotifierWithId(HString::from(
+    let toast_notifier = ToastNotificationManager::CreateToastNotifierWithId(HSTRING::from(
         "{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\\WindowsPowerShell\\v1.0\\powershell.exe",
     ))?;
 

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,0 +1,1 @@
+windows::include_bindings!();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,10 +32,7 @@ extern crate xml;
 #[macro_use]
 extern crate strum;
 
-#[allow(dead_code)]
-mod bindings {
-    ::windows::include_bindings!();
-}
+mod bindings;
 
 use bindings::{
     Windows::Data::Xml::Dom::XmlDocument,
@@ -51,7 +48,7 @@ mod windows_check;
 
 pub use windows::{
     Error,
-    HString,
+    HSTRING,
 };
 
 pub struct Toast {
@@ -299,7 +296,7 @@ impl Toast {
             }
         };
 
-        toast_xml.LoadXml(HString::from(format!(
+        toast_xml.LoadXml(HSTRING::from(format!(
             "<toast {}>
                     <visual>
                         <binding template=\"{}\">
@@ -323,7 +320,7 @@ impl Toast {
 
         // Show the toast.
         let toast_notifier =
-            ToastNotificationManager::CreateToastNotifierWithId(HString::from(&self.app_id))?;
+            ToastNotificationManager::CreateToastNotifierWithId(HSTRING::from(&self.app_id))?;
         let result = toast_notifier.Show(&toast_template);
         std::thread::sleep(std::time::Duration::from_millis(10));
         result

--- a/src/windows_check.rs
+++ b/src/windows_check.rs
@@ -1,12 +1,7 @@
 // Lifted from mattmccarty's work in os_info
-#[allow(dead_code)]
-mod bindings {
-    ::windows::include_bindings!();
-}
-
-use bindings::{
-    Windows::Win32::SystemServices::NTSTATUS,
-    Windows::Win32::WindowsProgramming::*,
+use crate::bindings::Windows::Win32::{
+    Foundation::NTSTATUS,
+    System::SystemInformation::*,
 };
 
 #[cfg(target_arch = "x86")]


### PR DESCRIPTION
We use cargo deny to lint our dependencies and try to keep a cleaner dependency graph with the least dependencies possible. This crate ends up bringing an pre 1 version of syn, which is a dependency of the windows crate. I don't know if this endsup changing the public interface, if it doesn't can we publish a new patch version of this?

Thanks in advance,
Jalal
