### PR TITLE
Added notification scenarios and own type alias for windows::runtime::Result

### DIFF
--- a/examples/action_simple.rs
+++ b/examples/action_simple.rs
@@ -1,8 +1,8 @@
 extern crate winrt_notification;
 
-use winrt_notification::{Duration, Toast, ToastAction, ToastActivatedEventArgs, ToastNotification};
+use winrt_notification::{Duration, Toast, ToastAction, ToastActivatedEventArgs, ToastNotification, Result};
 
-fn followup(_sender: &ToastNotification, args: &ToastActivatedEventArgs) -> windows::runtime::Result<()> {
+fn followup(_sender: &ToastNotification, args: &ToastActivatedEventArgs) -> Result<()> {
     if args.Arguments()? == "bird" {
         Toast::new(Toast::POWERSHELL_APP_ID)
             .text1("Really the bird?")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@ pub struct Toast {
     audio: String,
     app_id: String,
     actions: String,
+    scenario: String,
 }
 
 #[derive(Clone, Copy)]
@@ -121,6 +122,14 @@ pub enum IconCrop {
     Circular,
 }
 
+#[allow(dead_code)]
+#[derive(Clone, Copy)]
+pub enum Scenario {
+    Alarm,
+    Reminder,
+    IncomingCall,
+}
+
 pub type Result<T> = windows::runtime::Result<T>;
 
 impl Toast {
@@ -147,6 +156,7 @@ impl Toast {
             audio: String::new(),
             actions: String::new(),
             app_id: app_id.to_string(),
+            scenario: String::new(),
         }
     }
 
@@ -186,6 +196,21 @@ impl Toast {
         .to_owned();
         self
     }
+
+    /// Set the scenario of the toast
+    /// 
+    /// The system keeps the notification on screen until the user acts upon/dismisses it.
+    /// The system also plays the suitable notification sound as well.
+    pub fn scenario(mut self, scenario: Scenario) -> Toast {
+        self.scenario = match scenario {
+            Scenario::Alarm => "scenario=\"alarm\"",
+            Scenario::Reminder => "scenario=\"reminder\"",
+            Scenario::IncomingCall => "scenario=\"incomingCall\"",
+        }
+        .to_owned();
+        self
+    }
+
 
     /// Set the icon shown in the upper left of the toast
     ///
@@ -291,7 +316,7 @@ impl Toast {
         };
 
         toast_xml.LoadXml(HSTRING::from(format!(
-            "<toast {}>
+            "<toast {} {}>
                     <visual>
                         <binding template=\"{}\">
                         {}
@@ -301,7 +326,7 @@ impl Toast {
                     {}
                     <actions>{}</actions>
                 </toast>",
-            self.duration, template_binding, self.images, self.title, self.line1, self.line2, self.audio, self.actions,
+            self.duration, self.scenario, template_binding, self.images, self.title, self.line1, self.line2, self.audio, self.actions,
         )))?;
 
         // Create the toast

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,8 @@ pub enum IconCrop {
     Circular,
 }
 
+pub type Result<T> = windows::runtime::Result<T>;
+
 impl Toast {
     /// This can be used if you do not have a AppUserModelID.
     ///
@@ -271,7 +273,7 @@ impl Toast {
         self
     }
 
-    fn create_template(&self) -> windows::runtime::Result<ToastNotification> {
+    fn create_template(&self) -> Result<ToastNotification> {
         //using this to get an instance of XmlDocument
         let toast_xml = XmlDocument::new()?;
 
@@ -306,34 +308,34 @@ impl Toast {
         ToastNotification::CreateToastNotification(toast_xml)
     }
 
-    pub fn show_with_action<F>(&self, on_action: F) -> windows::runtime::Result<()>
+    pub fn show_with_action<F>(&self, on_action: F) -> Result<()>
     where
-        F: Fn(&ToastNotification, &ToastActivatedEventArgs) -> windows::runtime::Result<()> + 'static,
+        F: Fn(&ToastNotification, &ToastActivatedEventArgs) -> Result<()> + 'static,
     {
         self.show_with_optional_action_dismiss_failure(
             Some(on_action),
-            None::<fn(&ToastNotification, &ToastDismissedEventArgs) -> windows::runtime::Result<()>>,
-            None::<fn(&ToastNotification, &ToastFailedEventArgs) -> windows::runtime::Result<()>>,
+            None::<fn(&ToastNotification, &ToastDismissedEventArgs) -> Result<()>>,
+            None::<fn(&ToastNotification, &ToastFailedEventArgs) -> Result<()>>,
         )
     }
 
-    pub fn show_with_action_dismiss<F, F2>(&self, on_action: F, on_dismiss: F2) -> windows::runtime::Result<()>
+    pub fn show_with_action_dismiss<F, F2>(&self, on_action: F, on_dismiss: F2) -> Result<()>
     where
-        F: Fn(&ToastNotification, &ToastActivatedEventArgs) -> windows::runtime::Result<()> + 'static,
-        F2: Fn(&ToastNotification, &ToastDismissedEventArgs) -> windows::runtime::Result<()> + 'static,
+        F: Fn(&ToastNotification, &ToastActivatedEventArgs) -> Result<()> + 'static,
+        F2: Fn(&ToastNotification, &ToastDismissedEventArgs) -> Result<()> + 'static,
     {
         self.show_with_optional_action_dismiss_failure(
             Some(on_action),
             Some(on_dismiss),
-            None::<fn(&ToastNotification, &ToastFailedEventArgs) -> windows::runtime::Result<()>>,
+            None::<fn(&ToastNotification, &ToastFailedEventArgs) -> Result<()>>,
         )
     }
 
-    pub fn show_with_action_dismiss_failure<F, F2, F3>(&self, on_action: F, on_dismiss: F2, on_failure: F3) -> windows::runtime::Result<()>
+    pub fn show_with_action_dismiss_failure<F, F2, F3>(&self, on_action: F, on_dismiss: F2, on_failure: F3) -> Result<()>
     where
-        F: Fn(&ToastNotification, &ToastActivatedEventArgs) -> windows::runtime::Result<()> + 'static,
-        F2: Fn(&ToastNotification, &ToastDismissedEventArgs) -> windows::runtime::Result<()> + 'static,
-        F3: Fn(&ToastNotification, &ToastFailedEventArgs) -> windows::runtime::Result<()> + 'static,
+        F: Fn(&ToastNotification, &ToastActivatedEventArgs) -> Result<()> + 'static,
+        F2: Fn(&ToastNotification, &ToastDismissedEventArgs) -> Result<()> + 'static,
+        F3: Fn(&ToastNotification, &ToastFailedEventArgs) -> Result<()> + 'static,
     {
         self.show_with_optional_action_dismiss_failure(Some(on_action), Some(on_dismiss), Some(on_failure))
     }
@@ -344,11 +346,11 @@ impl Toast {
         on_action: Option<F>,
         on_dismiss: Option<F2>,
         on_failure: Option<F3>,
-    ) -> windows::runtime::Result<()>
+    ) -> Result<()>
     where
-        F: Fn(&ToastNotification, &ToastActivatedEventArgs) -> windows::runtime::Result<()> + 'static,
-        F2: Fn(&ToastNotification, &ToastDismissedEventArgs) -> windows::runtime::Result<()> + 'static,
-        F3: Fn(&ToastNotification, &ToastFailedEventArgs) -> windows::runtime::Result<()> + 'static,
+        F: Fn(&ToastNotification, &ToastActivatedEventArgs) -> Result<()> + 'static,
+        F2: Fn(&ToastNotification, &ToastDismissedEventArgs) -> Result<()> + 'static,
+        F3: Fn(&ToastNotification, &ToastFailedEventArgs) -> Result<()> + 'static,
     {
         let toast_template = self.create_template()?;
 
@@ -409,26 +411,26 @@ impl Toast {
     }
 
     /// Display the toast on the screen
-    pub fn show(&self) -> windows::runtime::Result<()> {
+    pub fn show(&self) -> Result<()> {
         self.show_with_optional_action_dismiss_failure(
-            None::<fn(&ToastNotification, &ToastActivatedEventArgs) -> windows::runtime::Result<()>>,
-            None::<fn(&ToastNotification, &ToastDismissedEventArgs) -> windows::runtime::Result<()>>,
-            None::<fn(&ToastNotification, &ToastFailedEventArgs) -> windows::runtime::Result<()>>,
+            None::<fn(&ToastNotification, &ToastActivatedEventArgs) -> Result<()>>,
+            None::<fn(&ToastNotification, &ToastDismissedEventArgs) -> Result<()>>,
+            None::<fn(&ToastNotification, &ToastFailedEventArgs) -> Result<()>>,
         )
     }
 }
 
 pub trait UserInputExt {
-    fn lookup<T: windows::runtime::RuntimeType>(&self, key: &str) -> windows::runtime::Result<IReference<T>>;
-    fn lookup_string(&self, key: &str) -> windows::runtime::Result<HSTRING>;
+    fn lookup<T: windows::runtime::RuntimeType>(&self, key: &str) -> Result<IReference<T>>;
+    fn lookup_string(&self, key: &str) -> Result<HSTRING>;
 }
 
 impl UserInputExt for ToastActivatedEventArgs {
-    fn lookup<T: windows::runtime::RuntimeType>(&self, key: &str) -> windows::runtime::Result<IReference<T>> {
+    fn lookup<T: windows::runtime::RuntimeType>(&self, key: &str) -> Result<IReference<T>> {
         self.UserInput()?.Lookup(key)?.cast::<IReference<T>>()
     }
 
-    fn lookup_string(&self, key: &str) -> windows::runtime::Result<HSTRING> {
+    fn lookup_string(&self, key: &str) -> Result<HSTRING> {
         self.lookup::<HSTRING>(key)?.GetString()
     }
 }


### PR DESCRIPTION
The windows::runtime::Result type was being returned directly from the action callbacks. This required the consuming app to import the windows crate if it wanted to handle callbacks.

I added a type alias for the same, with which the user can directly use this crate's Result type which further maps to the windows Result type, thus eliminating any need to import the windows crate.

I also added Scenario support incase someone wants a persistent notification for reminders, alarms or VoIP incoming calls.