### PR TITLE
updated windows crate to 0.34.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ xml-rs = "0.8.4"
 strum = { version = "0.22.0", features = ["derive"] }
 
 [target.'cfg(target_env = "msvc")'.dependencies.windows]
-version = "0.24.0"
+version = "0.34.0"
 features = [
     "Win32_Foundation",
     "Foundation_Collections",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ features = [
 ]
 
 [target.'cfg(target_env = "gnu")'.dependencies.windows]
-version = "0.24.0"
+version = "0.34.0"
 features = [
     "Win32_Foundation",
     "Foundation_Collections",

--- a/examples/without_library.rs
+++ b/examples/without_library.rs
@@ -14,7 +14,7 @@ use windows::{
     UI::Notifications::ToastNotificationManager,
 };
 
-pub use windows::runtime::{
+pub use windows::core::{
     Error,
     HSTRING,
 };
@@ -26,7 +26,7 @@ fn main() {
     std::thread::sleep(std::time::Duration::from_millis(10));
 }
 
-fn do_toast() -> windows::runtime::Result<()> {
+fn do_toast() -> windows::core::Result<()> {
     let toast_xml = XmlDocument::new()?;
 
     toast_xml.LoadXml(HSTRING::from(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ use std::path::Path;
 use xml::escape::escape_str_attribute;
 mod windows_check;
 
-pub use windows::runtime::{Error, HSTRING, Result};
+pub use windows::core::{Error, HSTRING, Result};
 pub use windows::UI::Notifications::ToastNotification;
 
 pub struct Toast {
@@ -283,7 +283,7 @@ impl Toast {
         self
     }
 
-    fn create_template(&self) -> windows::runtime::Result<ToastNotification> {
+    fn create_template(&self) -> windows::core::Result<ToastNotification> {
         //using this to get an instance of XmlDocument
         let toast_xml = XmlDocument::new()?;
 
@@ -325,7 +325,7 @@ impl Toast {
     }
 
     /// Display the toast on the screen
-    pub fn show(&self) -> windows::runtime::Result<()> {
+    pub fn show(&self) -> windows::core::Result<()> {
         let toast_template = self.create_template()?;
 
         let toast_notifier = ToastNotificationManager::CreateToastNotifierWithId(HSTRING::from(&self.app_id))?;


### PR DESCRIPTION
There was is a security vulnerability in previous versions of the windows crate ([see here](https://rustsec.org/advisories/RUSTSEC-2022-0008.html))

What was changed:
- updated windows crate version

- fixed compile issues due to some changes in the crate architecture (`windows::runtime` is now `windows::core`)  