### PR TITLE
Add support for actions and input fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,14 @@ documentation = "https://allenbenz.github.io/winrt-notification/0_5_0/winrt_noti
 repository = "https://github.com/allenbenz/winrt-notification"
 license = "MIT"
 exclude = [".vscode/*"]
-edition = '2018'
+edition = '2021'
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
 
 [dependencies]
 xml-rs = "0.8.4"
-strum = { version = "0.22.0", features = ["derive"] }
+strum = { version = "0.24.0", features = ["derive"] }
 
 [target.'cfg(target_env = "msvc")'.dependencies.windows]
 version = "0.24.0"

--- a/examples/actions.rs
+++ b/examples/actions.rs
@@ -1,0 +1,33 @@
+extern crate winrt_notification;
+
+use winrt_notification::{
+    Action,
+    Toast,
+    ToastWithHandlers,
+};
+
+fn main() {
+    let toast = Toast::new(Toast::POWERSHELL_APP_ID)
+        .title("toast with input")
+        .action(Action {
+            content: "Hey".to_string(),
+            arguments: "hey".to_string(),
+            place_to_context_menu: false,
+        })
+        .action(Action::from_content("Hey2"))
+        .action(Action {
+            content: "Context Action 1".to_string(),
+            arguments: "context 1".to_string(),
+            place_to_context_menu: true,
+        });
+    ToastWithHandlers::new(toast)
+        .on_activate(|args| {
+            println!("arguments: {}", args.get_arguments().unwrap()?);
+            // exit the waiting loop
+            std::process::exit(0);
+        })
+        .show()
+        .expect("unable to send notification");
+    // wait for activation
+    loop {}
+}

--- a/examples/handlers.rs
+++ b/examples/handlers.rs
@@ -1,0 +1,29 @@
+extern crate winrt_notification;
+use winrt_notification::{
+    Toast,
+    ToastWithHandlers,
+};
+
+fn main() {
+    let toast = Toast::new(Toast::POWERSHELL_APP_ID).title("toast with handlers");
+    ToastWithHandlers::new(toast)
+        .on_activate(|_| {
+            println!("activated");
+            // exit the waiting loop
+            std::process::exit(0);
+        })
+        .on_dismiss(|_, _| {
+            println!("dismissed");
+            // exit the waiting loop
+            std::process::exit(0);
+        })
+        .on_fail(|_, _| {
+            println!("failed!");
+            // exit the waiting loop
+            std::process::exit(0);
+        })
+        .show()
+        .expect("unable to send notification");
+    // wait for some event
+    loop {}
+}

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -8,11 +8,7 @@ use winrt_notification::{
 fn main() {
     Toast::new("application that needs a toast with an image")
         .hero(&Path::new("C:\\absolute\\path\\to\\image.jpeg"), "alt text")
-        .icon(
-            &Path::new("c:/this/style/works/too/image.png"),
-            IconCrop::Circular,
-            "alt text",
-        )
+        .icon(&Path::new("c:/this/style/works/too/image.png"), IconCrop::Circular, "alt text")
         .title("Lots of pictures here")
         .text1("One above the text as the hero")
         .text2("One to the left as an icon, and several below")

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -1,0 +1,26 @@
+extern crate winrt_notification;
+
+use winrt_notification::{
+    InputType,
+    Toast,
+    ToastWithHandlers,
+};
+
+fn main() {
+    let toast = Toast::new(Toast::POWERSHELL_APP_ID)
+        .title("toast with input")
+        .input(InputType::text_with_placeholder("input some text"), "first input")
+        .input(InputType::text_with_placeholder("and some more"), "second input");
+    ToastWithHandlers::new(toast)
+        .on_activate(|args| {
+            let input = args.get_user_input().unwrap()?;
+            println!("first input is {}", input["first input"]);
+            println!("second input is {}", input["second input"]);
+            // exit the waiting loop
+            std::process::exit(0);
+        })
+        .show()
+        .expect("unable to send notification");
+    // wait for activation
+    loop {}
+}

--- a/examples/reuse_toast.rs
+++ b/examples/reuse_toast.rs
@@ -1,5 +1,9 @@
 extern crate winrt_notification;
-use winrt_notification::{Duration, Sound, Toast};
+use winrt_notification::{
+    Duration,
+    Sound,
+    Toast,
+};
 
 fn main() {
     let duration = Duration::Short;

--- a/examples/selections.rs
+++ b/examples/selections.rs
@@ -1,0 +1,23 @@
+extern crate winrt_notification;
+
+use winrt_notification::{
+    InputType,
+    Toast,
+    ToastWithHandlers,
+};
+
+fn main() {
+    let toast = Toast::new(Toast::POWERSHELL_APP_ID)
+        .title("toast with selection")
+        .input(InputType::from_selection_contents(["1", "2", "3"]), "selection");
+    ToastWithHandlers::new(toast)
+        .on_activate(|args| {
+            println!("selected: {}", args.get_user_input().expect("no event arguments")?["selection"]);
+            // exit the waiting loop
+            std::process::exit(0);
+        })
+        .show()
+        .expect("unable to send notification");
+    // wait for activation
+    loop {}
+}

--- a/src/windows_check.rs
+++ b/src/windows_check.rs
@@ -10,7 +10,10 @@ mod internal {
 // but we know it's in ntdll which will always be present at runtime.
 #[cfg(target_env = "gnu")]
 mod internal {
-    use windows::Win32::System::LibraryLoader::{GetModuleHandleA, GetProcAddress};
+    use windows::Win32::System::LibraryLoader::{
+        GetModuleHandleA,
+        GetProcAddress,
+    };
 
     #[allow(non_upper_case_globals)]
     static mut CacheRtlGetNtVersionNumbers: Option<unsafe extern "system" fn() -> isize> = None;


### PR DESCRIPTION
This adds some support and examples for the following actions:
* Selection
* Text
* Button/ Action

To get the values from the actions and input fields some handlers were added.
These will be called by windows and execute user supplied closures.

To avoid breaking changes `ToastWithHandlers` won't be integrated in `Toast`. `ToastWithHandlers` requires an owned `self` because the handler closure will be moved. Technically it may be possible to work around this with some shared ownership of the handler closures but this could be difficult.

Should the crate get a new release so that users and other crates could use this soon?