### PR TITLE
Upgrade to windows 0.39.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ xml-rs = "0.8.4"
 strum = { version = "0.22.0", features = ["derive"] }
 
 [target.'cfg(target_env = "msvc")'.dependencies.windows]
-version = "0.37.0"
+version = "0.38.0"
 features = [
     "Win32_Foundation",
     "Foundation_Collections",
@@ -29,7 +29,7 @@ features = [
 ]
 
 [target.'cfg(target_env = "gnu")'.dependencies.windows]
-version = "0.37.0"
+version = "0.38.0"
 features = [
     "alloc",
     "Win32_Foundation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ xml-rs = "0.8.4"
 strum = { version = "0.22.0", features = ["derive"] }
 
 [target.'cfg(target_env = "msvc")'.dependencies.windows]
-version = "0.38.0"
+version = "0.39.0"
 features = [
     "Win32_Foundation",
     "Foundation_Collections",
@@ -29,9 +29,8 @@ features = [
 ]
 
 [target.'cfg(target_env = "gnu")'.dependencies.windows]
-version = "0.38.0"
+version = "0.39.0"
 features = [
-    "alloc",
     "Win32_Foundation",
     "Foundation_Collections",
     "Win32_System_SystemInformation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ xml-rs = "0.8.4"
 strum = { version = "0.22.0", features = ["derive"] }
 
 [target.'cfg(target_env = "msvc")'.dependencies.windows]
-version = "0.24.0"
+version = "0.37.0"
 features = [
     "Win32_Foundation",
     "Foundation_Collections",
@@ -29,8 +29,9 @@ features = [
 ]
 
 [target.'cfg(target_env = "gnu")'.dependencies.windows]
-version = "0.24.0"
+version = "0.37.0"
 features = [
+    "alloc",
     "Win32_Foundation",
     "Foundation_Collections",
     "Win32_System_SystemInformation",

--- a/examples/without_library.rs
+++ b/examples/without_library.rs
@@ -14,7 +14,7 @@ use windows::{
     UI::Notifications::ToastNotificationManager,
 };
 
-pub use windows::runtime::{
+pub use windows::core::{
     Error,
     HSTRING,
 };
@@ -26,7 +26,7 @@ fn main() {
     std::thread::sleep(std::time::Duration::from_millis(10));
 }
 
-fn do_toast() -> windows::runtime::Result<()> {
+fn do_toast() -> windows::core::Result<()> {
     let toast_xml = XmlDocument::new()?;
 
     toast_xml.LoadXml(HSTRING::from(

--- a/examples/without_library.rs
+++ b/examples/without_library.rs
@@ -29,7 +29,7 @@ fn main() {
 fn do_toast() -> windows::core::Result<()> {
     let toast_xml = XmlDocument::new()?;
 
-    toast_xml.LoadXml(HSTRING::from(
+    toast_xml.LoadXml(&HSTRING::from(
         format!(r#"<toast duration="long">
                 <visual>
                     <binding template="ToastGeneric">
@@ -48,10 +48,10 @@ fn do_toast() -> windows::core::Result<()> {
     ))).expect("the xml is malformed");
 
     // Create the toast and attach event listeners
-    let toast_template = ToastNotification::CreateToastNotification(toast_xml)?;
+    let toast_template = ToastNotification::CreateToastNotification(&toast_xml)?;
 
     // If you have a valid app id, (ie installed using wix) then use it here.
-    let toast_notifier = ToastNotificationManager::CreateToastNotifierWithId(HSTRING::from(
+    let toast_notifier = ToastNotificationManager::CreateToastNotifierWithId(&HSTRING::from(
         "{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\\WindowsPowerShell\\v1.0\\powershell.exe",
     ))?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ use std::path::Path;
 use xml::escape::escape_str_attribute;
 mod windows_check;
 
-pub use windows::runtime::{Error, HSTRING, Result};
+pub use windows::core::{Error, HSTRING, Result};
 pub use windows::UI::Notifications::ToastNotification;
 
 pub struct Toast {
@@ -283,7 +283,7 @@ impl Toast {
         self
     }
 
-    fn create_template(&self) -> windows::runtime::Result<ToastNotification> {
+    fn create_template(&self) -> windows::core::Result<ToastNotification> {
         //using this to get an instance of XmlDocument
         let toast_xml = XmlDocument::new()?;
 
@@ -325,7 +325,7 @@ impl Toast {
     }
 
     /// Display the toast on the screen
-    pub fn show(&self) -> windows::runtime::Result<()> {
+    pub fn show(&self) -> windows::core::Result<()> {
         let toast_template = self.create_template()?;
 
         let toast_notifier = ToastNotificationManager::CreateToastNotifierWithId(HSTRING::from(&self.app_id))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,7 +300,7 @@ impl Toast {
             }
         };
 
-        toast_xml.LoadXml(HSTRING::from(format!(
+        toast_xml.LoadXml(&HSTRING::from(format!(
             "<toast {} {}>
                     <visual>
                         <binding template=\"{}\">
@@ -321,14 +321,14 @@ impl Toast {
         )))?;
 
         // Create the toast
-        ToastNotification::CreateToastNotification(toast_xml)
+        ToastNotification::CreateToastNotification(&toast_xml)
     }
 
     /// Display the toast on the screen
     pub fn show(&self) -> windows::core::Result<()> {
         let toast_template = self.create_template()?;
 
-        let toast_notifier = ToastNotificationManager::CreateToastNotifierWithId(HSTRING::from(&self.app_id))?;
+        let toast_notifier = ToastNotificationManager::CreateToastNotifierWithId(&HSTRING::from(&self.app_id))?;
 
         // Show the toast.
         let result = toast_notifier.Show(&toast_template);

--- a/src/windows_check.rs
+++ b/src/windows_check.rs
@@ -18,7 +18,9 @@ mod internal {
     #[allow(non_snake_case)]
     pub unsafe fn RtlGetNtVersionNumbers(major: *mut u32, minor: *mut u32, build: *mut u32) {
         if CacheRtlGetNtVersionNumbers.is_none() {
-            CacheRtlGetNtVersionNumbers = GetProcAddress(GetModuleHandleA("ntdll.dll"), "RtlGetNtVersionNumbers");
+            if let Ok(handle) = GetModuleHandleA("ntdll.dll") {
+                CacheRtlGetNtVersionNumbers = GetProcAddress(handle, "RtlGetNtVersionNumbers");
+            }
         }
 
         if let Some(RtlGetNtVersionNumbers_FUNCTION) = CacheRtlGetNtVersionNumbers {

--- a/src/windows_check.rs
+++ b/src/windows_check.rs
@@ -10,6 +10,7 @@ mod internal {
 // but we know it's in ntdll which will always be present at runtime.
 #[cfg(target_env = "gnu")]
 mod internal {
+    use windows::core::PCSTR;
     use windows::Win32::System::LibraryLoader::{GetModuleHandleA, GetProcAddress};
 
     #[allow(non_upper_case_globals)]
@@ -17,9 +18,12 @@ mod internal {
 
     #[allow(non_snake_case)]
     pub unsafe fn RtlGetNtVersionNumbers(major: *mut u32, minor: *mut u32, build: *mut u32) {
+        const NTDLL: PCSTR = PCSTR::from_raw("ntdll.dll".as_bytes().as_ptr());
+        const RTL_GET_VERSION_NUMBERS: PCSTR = PCSTR::from_raw("RtlGetNtVersionNumbers".as_bytes().as_ptr());
+
         if CacheRtlGetNtVersionNumbers.is_none() {
-            if let Ok(handle) = GetModuleHandleA("ntdll.dll") {
-                CacheRtlGetNtVersionNumbers = GetProcAddress(handle, "RtlGetNtVersionNumbers");
+            if let Ok(handle) = GetModuleHandleA(NTDLL) {
+                CacheRtlGetNtVersionNumbers = GetProcAddress(handle, RTL_GET_VERSION_NUMBERS);
             }
         }
 


### PR DESCRIPTION
Just got hit by the security alert. Since there hasn't been any news at
#18 for a while, here's another one to bump it directly to 0.37.0.
