### PR TITLE
replace `xml-rs` with `quick-xml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = '2018'
 default-target = "x86_64-pc-windows-msvc"
 
 [dependencies]
-xml-rs = "0.8.4"
+quick-xml = "0.23.0"
 strum = { version = "0.22.0", features = ["derive"] }
 
 [target.'cfg(target_env = "msvc")'.dependencies.windows]

--- a/examples/without_library.rs
+++ b/examples/without_library.rs
@@ -1,8 +1,8 @@
 // How to create a toast without using this library
 
-extern crate xml;
+extern crate quick_xml;
+use quick_xml::escape::escape;
 use std::path::Path;
-use xml::escape::escape_str_attribute;
 
 // You need to have the windows crate in your Cargo.toml
 // with the following features:
@@ -44,7 +44,7 @@ fn do_toast() -> windows::runtime::Result<()> {
                 <audio src="ms-winsoundevent:Notification.SMS" />
                 <!-- <audio silent="true" /> -->
             </toast>"#,
-        escape_str_attribute(&Path::new("C:\\path_to_image_in_toast.jpg").display().to_string()),
+        std::str::from_utf8(escape(Path::new("C:\\path_to_image_in_toast.jpg").display().to_string().as_bytes()).as_ref()).expect("valid utf8"),
     ))).expect("the xml is malformed");
 
     // Create the toast and attach event listeners

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 //!
 //! * Windows 8.1 only supports a single image, the last image (icon, hero, image) will be the one on the toast
 
+extern crate quick_xml;
 /// for xml schema details check out:
 ///
 /// * https://docs.microsoft.com/en-us/uwp/schemas/tiles/toastschema/root-elements
@@ -28,7 +29,6 @@
 
 /// For actions look at https://docs.microsoft.com/en-us/dotnet/api/microsoft.toolkit.uwp.notifications.toastactionscustom?view=win-comm-toolkit-dotnet-7.0
 extern crate windows;
-extern crate xml;
 
 #[macro_use]
 extern crate strum;
@@ -40,7 +40,8 @@ use windows::{
 
 use std::path::Path;
 
-use xml::escape::escape_str_attribute;
+use quick_xml::escape::escape as escape_attr;
+use std::borrow::Cow;
 mod windows_check;
 
 pub use windows::runtime::{Error, HSTRING, Result};
@@ -334,6 +335,15 @@ impl Toast {
         let result = toast_notifier.Show(&toast_template);
         std::thread::sleep(std::time::Duration::from_millis(10));
         result
+    }
+}
+
+fn escape_str_attribute(s: &str) -> Cow<'_, str> {
+    let escaped = escape_attr(s.as_bytes());
+    match escaped {
+        Cow::Borrowed(_) => Cow::Borrowed(s),
+        // This is safe because we know that the string was valid UTF-8
+        Cow::Owned(e) => Cow::Owned(String::from_utf8(e).unwrap()),
     }
 }
 


### PR DESCRIPTION
`xml-rs` has become unmaintained and has some issues with integer overflows. https://rustsec.org/advisories/RUSTSEC-2022-0048.html
`quick-xml` is the recommended alternative.